### PR TITLE
scale all coordinates with the pixel ratio

### DIFF
--- a/lib/adapters/linux.coffee
+++ b/lib/adapters/linux.coffee
@@ -15,4 +15,14 @@ module.exports =
   handleDimensions: (x, y, w, h) ->
     menubar = atom.getSize().height - document.documentElement.offsetHeight
     aP = atom.getPosition()
+
+    # scale all coordinates with pixel ratio
+    x = Math.floor(window.devicePixelRatio * x)
+    y = Math.floor(window.devicePixelRatio * y)
+    w = Math.floor(window.devicePixelRatio * w)
+    h = Math.floor(window.devicePixelRatio * h)
+    menubar = Math.floor(window.devicePixelRatio * menubar)
+    aP.x = Math.floor(window.devicePixelRatio * aP.x)
+    aP.y = Math.floor(window.devicePixelRatio * aP.y)
+
     {x: x + aP.x, y: y + aP.y + menubar, w: w, h: h}


### PR DESCRIPTION
When using a scaling factor (different than 1) the expected viewport is shifted to the top left and smaller than expected. See #3 for more details about what I experienced.

This patch scales all coordinates with the [window.devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). With this change the location as well as the size of the recorded animation is correct for me.