### PR TITLE
alt-shift-t to record the text editor area, without the tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Records the entire atom workspace
 Records the tree view
 ### Screen Recorder: Record Active Pane
 Records the current active pane
+### Screen Recorder: Record Active Text Editor
+Records the current active text editing area
 ### Screen Recorder: Open Select Area
 Opens a layer when you can select the area to record
 ### Screen Recorder: Stop Recording

--- a/keymaps/screen-recorder.cson
+++ b/keymaps/screen-recorder.cson
@@ -3,6 +3,7 @@
   'alt-shift-w': 'screen-recorder:record-window'
   'alt-shift-q': 'screen-recorder:record-tree-view'
   'alt-shift-d': 'screen-recorder:record-active-pane'
+  'alt-shift-t': 'screen-recorder:record-active-texteditor'
   'alt-shift-z': 'screen-recorder:stop-recording'
   'alt-shift-x': 'screen-recorder:cancel-recording'
 

--- a/lib/screen-recorder.coffee
+++ b/lib/screen-recorder.coffee
@@ -58,6 +58,7 @@ module.exports = ScreenRecorder =
       'screen-recorder:record-window': => @recordWindow()
       'screen-recorder:record-tree-view': => @recordTreeView()
       'screen-recorder:record-active-pane': => @recordActivePane()
+      'screen-recorder:record-active-texteditor': => @recordActiveTexteditor()
       'screen-recorder:stop-recording': => @stopRecording()
       'screen-recorder:cancel-recording': => @cancelRecording()
       'screen-recorder:open-recording': => @openRecordingList()
@@ -101,6 +102,13 @@ module.exports = ScreenRecorder =
     pane = atom.workspace.getActivePane()
     paneElement = atom.views.getView(pane)
     r = paneElement.getBoundingClientRect()
+    @recorderManager
+      .startRecording r.left, r.top,  r.right - r.left, r.bottom - r.top
+
+  recordActiveTexteditor: ->
+    texteditor = atom.workspace.getActiveTextEditor()
+    texteditorElement = atom.views.getView(texteditor)
+    r = texteditorElement.getBoundingClientRect()
     @recorderManager
       .startRecording r.left, r.top,  r.right - r.left, r.bottom - r.top
 

--- a/menus/screen-recorder.cson
+++ b/menus/screen-recorder.cson
@@ -21,6 +21,10 @@
           'command': 'screen-recorder:record-active-pane'
         }
         {
+          'label': 'Record active text area'
+          'command': 'screen-recorder:record-active-texteditor'
+        }
+        {
           'label': 'Open recording'
           'command': 'screen-recorder:open-recording'
         }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "screen-recorder:record-window",
       "screen-recorder:record-tree-view",
       "screen-recorder:record-active-pane",
+      "screen-recorder:record-active-texteditor",
       "screen-recorder:open-recording"
     ]
   },


### PR DESCRIPTION
normally, i need the text editor area, without the tabs on top...

personally, i would replace the current "pane" option by the text area only, but i guess some people love showing their beautiful tabs list : - )